### PR TITLE
Generate paired-end reads.

### DIFF
--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -17,10 +17,11 @@ localrules: all
 
 rule all:
     input:
-        [config['output']['fasta'].values()]
+        expand("{prefix}_{paired}.fq", prefix=[os.path.splitext(f)[0] for f in config['output']['fasta'].values()], paired=[1,2])
 
 # include rules
 include: "rules/sim_genomes.smk"
+include: "rules/sim_reads.smk"
 
 # rule all:
 #   input:

--- a/snakemake/analysis.yaml
+++ b/snakemake/analysis.yaml
@@ -22,5 +22,16 @@ output:
 #   bam_idx: .bam.bai
 # 
 # SAMPLES : ['G1', 'G2', 'N1', 'N2', 'N3']
-# coverage : [5,10,15,20,25,30]
-# insert_size : [300,350,400,450,500]
+
+#sim_genomes:
+#
+sim_reads:
+  seed: 1000
+  stdev: 10
+  read_len: 150
+  profile: HSXt
+  coverage: 30
+  insert_size: 500
+    # min: 300
+    # max: 500
+    # step: 50

--- a/snakemake/rules/sim_reads.smk
+++ b/snakemake/rules/sim_reads.smk
@@ -1,0 +1,34 @@
+rule art_illumina:
+    input:
+        fasta = "{prefix}.fasta"
+    params:
+        seed = config['sim_reads']['seed'],
+        profile = config['sim_reads']['profile'],
+        read_len = config['sim_reads']['read_len'],
+        stdev = config['sim_reads']['stdev'],
+        coverage = config['sim_reads']['coverage'],
+        insert_size = config['sim_reads']['insert_size']
+    output:
+        fastq1 = '{prefix}_1.fq',
+        fastq2 = '{prefix}_2.fq'
+    conda:
+        "../environment.yaml"
+    shell:
+        """
+        set -xe
+        PREFIX="$(basename "{input.fasta}" .fasta)"
+        OUTDIR="$(dirname "{input.fasta}")"
+
+        art_illumina \
+            -ss {params.profile} \
+            -M \
+            -i {input.fasta} \
+            -p \
+            -l {params.read_len} \
+            -f {params.coverage} \
+            -m {params.insert_size} \
+            -s {params.stdev} \
+            -na \
+            -rs {params.seed} \
+            -o ${{OUTDIR}}/${{PREFIX}}_
+        """


### PR DESCRIPTION
Added step to simulate paired-end reads from each (diploid) FASTA file (i.e., `hm`, `hmsv` and `htsv`). Note: only a subset of all `art_illumina` args are parametrized or exposed in `analysis.yaml`.