### PR TITLE
Use TMPDIR to sort BAM files #38.

### DIFF
--- a/snakemake/analysis.yaml
+++ b/snakemake/analysis.yaml
@@ -1,5 +1,7 @@
 ---
-threads: -1  # Samtools & BWA (default: -1 = use available cores)
+threads: -1  # Samtools & BWA (default: -1 = set dynamically based on available cores)
+memory: -1   # Samtools (default: -1 = set dynamically based on free memory per core [MB])
+tmpspace: 0  # Samtools (default: 0 [MB])
 
 # I/O files
 input:

--- a/snakemake/helper_functions.py
+++ b/snakemake/helper_functions.py
@@ -66,5 +66,15 @@ def get_mem():
 
     :returns: (int) in MB
     """
-    mem = ps.virtual_memory().free / get_nthreads() / 2**20
-    return int(mem)
+    if config.memory < 0:
+        return int(ps.virtual_memory().free / get_nthreads() / 2**20)
+    return config.memory
+
+
+def get_tmpspace():
+    """
+    Get the amount of temporary space used by `samtools sort`.
+
+    :returns (int) in MB
+    """
+    return config.tmpspace

--- a/snakemake/rules/map_reads.smk
+++ b/snakemake/rules/map_reads.smk
@@ -31,13 +31,15 @@ rule bwa_mem:
                            'cov_' + str(max(config.simulation.coverage)),
                            '{genotype}' + config.filext.bam)
     params:
-        read_group = "@RG\\tID:{0}\\tLB:{0}\\tSM:{0}".format('{genotype}')
+        read_group = "@RG\\tID:{0}\\tLB:{0}\\tSM:{0}".format('{genotype}'),
+        tmpdir = os.environ['TMPDIR'] if 'TMPDIR' in os.environ else '/tmp'
     conda:
         "../environment.yaml"
     threads:
         get_nthreads()
     resources:
-        mem_mb = get_mem()
+        mem_mb = get_mem(),
+        tmp_mb = get_tmpspace()
     shell:
         """
         set -xe
@@ -46,7 +48,11 @@ rule bwa_mem:
             -t {threads} \
             -R "{params.read_group}" \
             "{input.fasta}" "{input.fastq1}" "{input.fastq2}" | \
-        samtools sort -@ {threads} -m {resources.mem_mb}M -o "{output.bam}"
+        samtools sort \
+            -@ {threads} \
+            -m {resources.mem_mb}M \
+            -T "{params.tmpdir}" \
+            -o "{output.bam}"
         rm -f "{input.fastq1}" "{input.fastq2}"
         """
 

--- a/snakemake/tests/test_helper_functions.py
+++ b/snakemake/tests/test_helper_functions.py
@@ -54,3 +54,9 @@ def test_get_mem():
     result = hf.get_mem()
     expected = int(ps.virtual_memory().free / hf.get_nthreads() / 2**20)
     assert result == pytest.approx(expected, tolerance)
+
+
+def test_get_tmpspace():
+    result = hf.get_tmpspace()
+    expected = 0
+    assert result == expected

--- a/snakemake/validator/__init__.py
+++ b/snakemake/validator/__init__.py
@@ -138,9 +138,12 @@ class Analysis:
     """
     Analysis class to hold all nodes.
     """
-    def __init__(self, threads: int, input: Input, output: Output,
-                 filext: FileExtension, simulation: Simulation) -> None:
+    def __init__(self, threads: int, memory: int, tmpspace: int, input: Input,
+                 output: Output, filext: FileExtension, simulation: Simulation) \
+                 -> None:
         self.threads = threads
+        self.memory = memory
+        self.tmpspace = tmpspace
         self.input = input
         self.output = output
         self.filext = filext


### PR DESCRIPTION
- added  -T option to _samtools sort_ 
- added `tmpspace` and (unrelated) `memory` keys to `analysis.yaml`